### PR TITLE
Additional geom wrappers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,29 @@ jobs:
   main:
     runs-on: ubuntu-20.04
     steps:
-    - name: Install dependencies
+    - name: Cache geos
+      id: cache-geos
+      uses: actions/cache@v3
+      with:
+        path: ~/geos-3.10.2
+        key: ${{ runner.os }}-geos3102-1
+    - name: Build geos
+      if: steps.cache-geos.outputs.cache-hit != 'true'
       run: |
-        sudo apt-get install -y libgeos-dev
+        cd ~
+        wget http://download.osgeo.org/geos/geos-3.10.2.tar.bz2
+        tar xvfj geos-3.10.2.tar.bz2
+        cd geos-3.10.2
+        mkdir _build
+        cd _build
+        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
+        make
+        ctest
+    - name: Install geos
+      run: |
+        cd ~/geos-3.10.2/_build
+        sudo make install
+        sudo ldconfig
     - uses: actions/setup-go@v2
       with:
         go-version: 1.x
@@ -30,9 +50,29 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     steps:
-    - name: Install dependencies
+    - name: Cache geos
+      id: cache-geos
+      uses: actions/cache@v3
+      with:
+        path: ~/geos-3.10.2
+        key: ${{ runner.os }}-geos3102-1
+    - name: Build geos
+      if: steps.cache-geos.outputs.cache-hit != 'true'
       run: |
-        sudo apt-get install -y libgeos-dev
+        cd ~
+        wget http://download.osgeo.org/geos/geos-3.10.2.tar.bz2
+        tar xvfj geos-3.10.2.tar.bz2
+        cd geos-3.10.2
+        mkdir _build
+        cd _build
+        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
+        make
+        ctest
+    - name: Install geos
+      run: |
+        cd ~/geos-3.10.2/_build
+        sudo make install
+        sudo ldconfig
     - uses: actions/setup-go@v2
       with:
         go-version: 1.x

--- a/context.go
+++ b/context.go
@@ -17,6 +17,7 @@ type Context struct {
 	wkbWriter        *C.struct_GEOSWKBWriter_t
 	wktReader        *C.struct_GEOSWKTReader_t
 	wktWriter        *C.struct_GEOSWKTWriter_t
+	jsonReader       *C.struct_GEOSGeoJSONReader_t
 	err              error
 	geomFinalizeFunc func(*Geom)
 }
@@ -166,6 +167,19 @@ func (c *Context) NewGeomFromWKT(wkt string) (*Geom, error) {
 	wktCStr := C.CString(wkt)
 	defer C.GEOSFree_r(c.handle, unsafe.Pointer(wktCStr))
 	return c.newGeom(C.GEOSWKTReader_read_r(c.handle, c.wktReader, wktCStr), nil), c.err
+}
+
+// NewGeomFromJSON parses a geometry in JSON format from json.
+func (c *Context) NewGeomFromJSON(json string) (*Geom, error) {
+	c.Lock()
+	defer c.Unlock()
+	c.err = nil
+	if c.jsonReader == nil {
+		c.jsonReader = C.GEOSGeoJSONReader_create_r(c.handle)
+	}
+	jsonCStr := C.CString(json)
+	defer C.GEOSFree_r(c.handle, unsafe.Pointer(jsonCStr))
+	return c.newGeom(C.GEOSGeoJSONReader_readGeometry_r(c.handle, c.jsonReader, jsonCStr), nil), c.err
 }
 
 // NewLinearRing returns a new linear ring populated with coords.

--- a/defaultcontext.go
+++ b/defaultcontext.go
@@ -58,6 +58,11 @@ func NewGeomFromWKT(wkt string) (*Geom, error) {
 	return defaultContext.NewGeomFromWKT(wkt)
 }
 
+// NewGeomFromJSON parses a geometry in GeoJson format from json.
+func NewGeomFromJSON(json string) (*Geom, error) {
+	return defaultContext.NewGeomFromJSON(json)
+}
+
 // NewLinearRing returns a new linear ring populated with coords.
 func NewLinearRing(coords [][]float64) *Geom {
 	return defaultContext.NewLinearRing(coords)

--- a/geom.go
+++ b/geom.go
@@ -258,6 +258,34 @@ func (g *Geom) InteriorRing(n int) *Geom {
 	return g.context.newNonNilGeom(C.GEOSGetInteriorRingN_r(g.context.handle, g.geom, C.int(n)), g)
 }
 
+// Buffer() returns a buffer polygon with width w.
+func (g *Geom) Buffer(width float64, quadsegs int) *Geom {
+	g.mustNotBeDestroyed()
+	g.context.Lock()
+	defer g.context.Unlock()
+
+	return g.context.newNonNilGeom(C.GEOSBuffer_r(g.context.handle, g.geom, C.double(width), C.int(quadsegs)), g)
+}
+
+//UnaryUnion() returns the union of all components of a single geometry. Usually used to convert a collection into the smallest set of polygons that cover the same area.
+func (g *Geom) UnaryUnion() *Geom {
+	g.mustNotBeDestroyed()
+	g.context.Lock()
+	defer g.context.Unlock()
+
+	return g.context.newNonNilGeom(C.GEOSUnaryUnion_r(g.context.handle, g.geom), g)
+}
+
+//Densifies a geometry using a given distance tolerance.
+//Additional vertices will be added to every line segment that is greater this tolerance; these vertices will evenly subdivide that segment.
+func (g *Geom) Densify(tolerance float64) *Geom {
+	g.mustNotBeDestroyed()
+	g.context.Lock()
+	defer g.context.Unlock()
+
+	return g.context.newNonNilGeom(C.GEOSDensify_r(g.context.handle, g.geom, C.double(tolerance)), g)
+}
+
 // Intersection returns the intersection between g and other.
 func (g *Geom) Intersection(other *Geom) *Geom {
 	g.mustNotBeDestroyed()

--- a/geom.go
+++ b/geom.go
@@ -268,7 +268,7 @@ func (g *Geom) Buffer(width float64, quadsegs int) *Geom {
 	return g.context.newNonNilGeom(C.GEOSBuffer_r(g.context.handle, g.geom, C.double(width), C.int(quadsegs)), g)
 }
 
-//UnaryUnion() returns the union of all components of a single geometry. Usually used to convert a collection into the smallest set of polygons that cover the same area.
+// UnaryUnion() returns the union of all components of a single geometry. Usually used to convert a collection into the smallest set of polygons that cover the same area.
 func (g *Geom) UnaryUnion() *Geom {
 	g.mustNotBeDestroyed()
 	g.context.Lock()
@@ -277,8 +277,8 @@ func (g *Geom) UnaryUnion() *Geom {
 	return g.context.newNonNilGeom(C.GEOSUnaryUnion_r(g.context.handle, g.geom), g)
 }
 
-//Densifies a geometry using a given distance tolerance.
-//Additional vertices will be added to every line segment that is greater this tolerance; these vertices will evenly subdivide that segment.
+// Densifies a geometry using a given distance tolerance.
+// Additional vertices will be added to every line segment that is greater this tolerance; these vertices will evenly subdivide that segment.
 func (g *Geom) Densify(tolerance float64) *Geom {
 	g.mustNotBeDestroyed()
 	g.context.Lock()
@@ -619,7 +619,7 @@ func (g *Geom) Area() float64 {
 	return area
 }
 
-//Calculate the length of a geometry.
+// Calculate the length of a geometry.
 func (g *Geom) Length() float64 {
 	g.mustNotBeDestroyed()
 	g.context.Lock()
@@ -631,7 +631,7 @@ func (g *Geom) Length() float64 {
 	return area
 }
 
-//Returns a linestring geometry which represents the minimum diameter of the geometry.
+// Returns a linestring geometry which represents the minimum diameter of the geometry.
 func (g *Geom) MinimumWidth() *Geom {
 	g.mustNotBeDestroyed()
 	g.context.Lock()
@@ -656,7 +656,7 @@ func (g *Geom) mustNotBeDestroyed() {
 	}
 }
 
-//implements UnmarshalJSON interface
+// Implements UnmarshalJSON interface
 func (g *Geom) UnmarshalJSON(b []byte) error {
 	c := defaultContext
 	c.Lock()
@@ -667,19 +667,19 @@ func (g *Geom) UnmarshalJSON(b []byte) error {
 	}
 	jsonCStr := C.CString(string(b))
 	defer C.GEOSFree_r(c.handle, unsafe.Pointer(jsonCStr))
-	new_geom := C.GEOSGeoJSONReader_readGeometry_r(c.handle, c.jsonReader, jsonCStr)
+	newgeom := C.GEOSGeoJSONReader_readGeometry_r(c.handle, c.jsonReader, jsonCStr)
 	var (
 		typeID           C.int
 		numGeometries    C.int
 		numPoints        C.int
 		numInteriorRings C.int
 	)
-	if C.c_GEOSGeomGetInfo_r(c.handle, new_geom, &typeID, &numGeometries, &numPoints, &numInteriorRings) == 0 {
+	if C.c_GEOSGeomGetInfo_r(c.handle, newgeom, &typeID, &numGeometries, &numPoints, &numInteriorRings) == 0 {
 		panic(c.err)
 	}
 
 	g.context = c
-	g.geom = new_geom
+	g.geom = newgeom
 	g.parent = nil
 	g.typeID = GeometryTypeID(typeID)
 	g.numGeometries = int(numGeometries)
@@ -688,5 +688,4 @@ func (g *Geom) UnmarshalJSON(b []byte) error {
 
 	runtime.SetFinalizer(g, (*Geom).finalize)
 	return c.err
-
 }


### PR DESCRIPTION
**- Add geom wrappers for:**
- UnaryUnion()
- Densify()
- Area()
- Length()
- MinimumWidth()

**- Add `encoding/json.Unmarshaler` implementation for low-level geos geometries.**

**- Test environment update to geos 3.10.2**
