### PR TITLE
Add Project & ProjectNormalize Geom functions

### DIFF
--- a/geom_test.go
+++ b/geom_test.go
@@ -171,6 +171,8 @@ func TestGeomMethods(t *testing.T) {
 		assert.Equal(t, unitSquare.HausdorffDistance(mustNewGeomFromWKT(t, c, "LINESTRING (0 0, 0 1)")), 1.)
 		assert.Equal(t, unitSquare.HausdorffDistanceDensify(mustNewGeomFromWKT(t, c, "LINESTRING (0 0, 0 1)"), 0.01), 1.)
 	}
+	assert.Equal(t, eastWestLine.ProjectNormalized(mustNewGeomFromWKT(t, c, "Point (0.5 0.5)")), 0.5)
+	assert.Equal(t, eastWestLine.Project(mustNewGeomFromWKT(t, c, "Point (0.5 0.5)")), 0.5)
 	assert.True(t, northSouthLine.Intersects(eastWestLine))
 	assert.False(t, southEastSquare.Intersects(mustNewGeomFromWKT(t, c, "LINESTRING (0 0, 0 1)")))
 	if versionEqualOrGreaterThan(3, 8, 0) {

--- a/geommethods.go
+++ b/geommethods.go
@@ -597,6 +597,30 @@ func (g *Geom) Overlaps(other *Geom) bool {
 	}
 }
 
+// Project returns the distance of other(a point) projected onto g(a line) from the start of the line.
+func (g *Geom) Project(other *Geom) float64 {
+	g.mustNotBeDestroyed()
+	g.context.Lock()
+	defer g.context.Unlock()
+	if other.context != g.context {
+		other.context.Lock()
+		defer other.context.Unlock()
+	}
+	return float64(C.GEOSProject_r(g.context.handle, g.geom, other.geom))
+}
+
+// ProjectNormalized returns the proportional distance of other(a point) projected onto g(a line) from the start of the line. For example, a point that projects to the middle of a line would be return 0.5.
+func (g *Geom) ProjectNormalized(other *Geom) float64 {
+	g.mustNotBeDestroyed()
+	g.context.Lock()
+	defer g.context.Unlock()
+	if other.context != g.context {
+		other.context.Lock()
+		defer other.context.Unlock()
+	}
+	return float64(C.GEOSProjectNormalized_r(g.context.handle, g.geom, other.geom))
+}
+
 // SetPrecision changes the coordinate precision of g.
 func (g *Geom) SetPrecision(gridSize float64, flags PrecisionRule) *Geom {
 	g.mustNotBeDestroyed()

--- a/geommethods.go.tmpl
+++ b/geommethods.go.tmpl
@@ -110,11 +110,15 @@ func (g *Geom) {{ .name }}(other *Geom{{ range .extraArgs }}, {{ .name }} {{ .ty
 		other.context.Lock()
 		defer other.context.Unlock()
 	}
+    {{- if .valueReturned }}
+	return float64(C.{{ $geosFunction }}(g.context.handle, g.geom, other.geom{{ range .extraArgs }}, {{ .type | cType }}({{ .name }}){{ end }}))
+    {{- else }}
 	var {{ $varName }} float64
 	if C.{{ $geosFunction }}(g.context.handle, g.geom, other.geom{{ range .extraArgs }}, {{ .type | cType }}({{ .name }}){{ end }}, (*C.double)(&{{ $varName }})) == 0 {
 		panic(g.context.err)
 	}
 	return {{ $varName }}
+    {{- end }}
 }
 
 {{-  end }}

--- a/geommethods.yaml
+++ b/geommethods.yaml
@@ -231,6 +231,14 @@
 #    type: uint
 #  - name: vertexNumFraction
 #    type: float64
+- name: Project
+  comment: returns the distance of other(a point) projected onto g(a line) from the start of the line
+  type: float64BinaryProperty
+  valueReturned: true
+- name: ProjectNormalized
+  comment: returns the proportional distance of other(a point) projected onto g(a line) from the start of the line. For example, a point that projects to the middle of a line would be return 0.5
+  type: float64BinaryProperty
+  valueReturned: true
 - name: SetPrecision
   comment: changes the coordinate precision of g
   type: unary


### PR DESCRIPTION
I'd like to be able to use `ProjectNormalize`, so I've added it and `Project` to the geom funcs. It _returns_ a double rather than accepting it as a pointer, so I added the `valueReturned` flag to the templating of `float64BinaryProperty` to support those kind of funcs too.