### PR TITLE
Save cgo error handle in context

### DIFF
--- a/context.go
+++ b/context.go
@@ -25,6 +25,7 @@ type Context struct {
 	wktReader          func() *WKTReader
 	wktWriter          func() *WKTWriter
 	err                error
+	errPHandle         cgo.Handle
 }
 
 // NewContext returns a new Context.
@@ -67,14 +68,14 @@ func NewContext() *Context {
 	c.wktWriter = sync.OnceValue(func() *WKTWriter {
 		return c.NewWKTWriter()
 	})
-	errPHandle := cgo.NewHandle(&c.err)
-	runtime.AddCleanup(c, cgo.Handle.Delete, errPHandle)
+	c.errPHandle = cgo.NewHandle(&c.err)
+	runtime.AddCleanup(c, cgo.Handle.Delete, c.errPHandle)
 	// FIXME golangci-lint complains about the following line saying: Error:
 	// dupSubExpr: suspicious identical LHS and RHS for `==` operator (gocritic)
 	// As the line does not contain an `==` operator, disable gocritic on this
 	// line.
 	//nolint:gocritic
-	C.GEOSContext_setErrorMessageHandler_r(c.cHandle, C.GEOSMessageHandler_r(C.c_errorMessageHandler), unsafe.Pointer(&errPHandle))
+	C.GEOSContext_setErrorMessageHandler_r(c.cHandle, C.GEOSMessageHandler_r(C.c_errorMessageHandler), unsafe.Pointer(&c.errPHandle))
 	return c
 }
 


### PR DESCRIPTION
## Issue

Hey there, we encountered this bug in our unit test coverage after switching to v0.20.2:
```go
import "github.com/twpayne/go-geos/geometry"
// .. somewhere in a func, testing parsing of invalid WKT
extentWKT := "Robert'); DROP TABLE Students;--"
geom, err = geometry.NewGeometryFromWKT(extentWKT)
	if err != nil {
		return nil, err
	}
```

Stacktrace:
```
panic: runtime/cgo: misuse of an invalid Handle [recovered, repanicked]

goroutine 83 [running]:
testing.tRunner.func1.2({0x106d88020, 0x1070bf500})
	/Users/lorenzo/.local/share/mise/installs/go/1.26.1/src/testing/testing.go:1974 +0x1a0
testing.tRunner.func1()
	/Users/lorenzo/.local/share/mise/installs/go/1.26.1/src/testing/testing.go:1977 +0x318
panic({0x106d88020?, 0x1070bf500?})
	/Users/lorenzo/.local/share/mise/installs/go/1.26.1/src/runtime/panic.go:860 +0x12c
runtime/cgo.Handle.Value(0x21c9c07db2d8?)
	/Users/lorenzo/.local/share/mise/installs/go/1.26.1/src/runtime/cgo/handle.go:130 +0x60
github.com/twpayne/go-geos.go_errorMessageHandler(0x10a520a18, 0x21c9bffcb808?)
	/Users/lorenzo/go/pkg/mod/github.com/twpayne/go-geos@v0.20.2/context.go:213 +0x24
github.com/twpayne/go-geos._Cfunc_GEOSWKTReader_read_r(0x10a520a10, 0x9bec280e0, 0x10a521480)
	_cgo_gotypes.go:2746 +0x30
github.com/twpayne/go-geos.(*WKTReader).Read.func2(...)
	/Users/lorenzo/go/pkg/mod/github.com/twpayne/go-geos@v0.20.2/wktreader.go:39
github.com/twpayne/go-geos.(*WKTReader).Read(0x21c9c07ba580, {0x1058f6328?, 0x107368a20?})
	/Users/lorenzo/go/pkg/mod/github.com/twpayne/go-geos@v0.20.2/wktreader.go:39 +0x180
github.com/twpayne/go-geos.(*Context).NewGeomFromWKT(0x21c9c07db658?, {0x1058f6328, 0x20})
	/Users/lorenzo/go/pkg/mod/github.com/twpayne/go-geos@v0.20.2/context.go:108 +0x38
github.com/twpayne/go-geos.NewGeomFromWKT(...)
	/Users/lorenzo/go/pkg/mod/github.com/twpayne/go-geos@v0.20.2/defaultcontext.go:63
github.com/twpayne/go-geos/geometry.NewGeometryFromWKT({0x1058f6328?, 0x104a3948c?})
	/Users/lorenzo/go/pkg/mod/github.com/twpayne/go-geos@v0.20.2/geometry/text.go:7 +0x38
```

The issue is not 100% reproducible and never occurs in debug mode, so we did some digging and came to the following conclusion:

- `errPHandle` (a `cgo.Handle`, which is just a `uintptr`) is a **local variable** on `NewContext()`'s stack frame
- `unsafe.Pointer(&errPHandle)` — the address of that local — is being handed to C as the error handler's `userdata`
-  when `NewContext()` returns, that stack slot is free to be reused by the next function call, leaving the C-side pointer dangling
- if GEOS later calls the error handler (on invalid WKT input), it reads garbage or zero from that stale address, causing the above panic

The issue most likely doesn't show up in debug mode due to `-gcflags='all=-N -l'`, alongside other disabled compiler optimizations.  If the stack frame becomes large enough, or the compiler doesn't reuse stack slots for different variables across the lifetime of a function call, the issue doesn't occur.

The above is just an assumption, but after including the suggested fix in our codebase, the error went away so I'm submitting the PR.

## Environment

**OS**: MacOS 26 / golang:1.26-alpine (CI environment)
**Arch**: arm64 / amd64
**geos version**: 3.14.1
**go-geos version**: v0.20.2

## Fix description

Store the cgo error handle within the `Context` struct, so it won't get overwritten and there is no dangling pointer anymore.