### PR TITLE
feat: make NewGeometryCollection take ownership of unowned geoms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ unaware.
 ## Ownership
 
 Returned sub-geometries (e.g. polygon rings or geometries in a collection) and
-coordinate sequences are owned by the geometry and are only valid for as long as
-the original geometry exists. If you need to persist a sub-geometry for longer
-than the original geometry you must clone it.
+coordinate sequences are owned by the geometry and will keep the geometry alive
+with a reference to it. Collections take ownership of all their geometries:
+directly if the geometry is unowned, or via cloning for an already-owned
+geometry.
 
 ## Errors, exceptions, and panics
 

--- a/context_test.go
+++ b/context_test.go
@@ -292,8 +292,8 @@ func TestPolygonize(t *testing.T) {
 				geom := mustNewGeomFromWKT(t, c, geomWKT)
 				geoms = append(geoms, geom)
 			}
-			assert.Equal(t, mustNewGeomFromWKT(t, c, tc.expectedWKT), c.Polygonize(geoms))
-			assert.Equal(t, mustNewGeomFromWKT(t, c, tc.expectedValidWKT), c.PolygonizeValid(geoms))
+			assert.Equal(t, mustNewGeomFromWKT(t, c, tc.expectedWKT), c.Polygonize(geoms), assert.Exclude[runtime.Cleanup]())
+			assert.Equal(t, mustNewGeomFromWKT(t, c, tc.expectedValidWKT), c.PolygonizeValid(geoms), assert.Exclude[runtime.Cleanup]())
 		})
 	}
 }
@@ -310,6 +310,7 @@ func TestPolygonizeMultiContext(t *testing.T) {
 				mustNewGeomFromWKT(t, c1, "LINESTRING (1 1,0 1)"),
 				mustNewGeomFromWKT(t, c2, "LINESTRING (0 1,0 0)"),
 			}),
+			assert.Exclude[runtime.Cleanup](),
 		)
 	}
 }

--- a/geojson/geojson_test.go
+++ b/geojson/geojson_test.go
@@ -1,6 +1,7 @@
 package geojson_test
 
 import (
+	"runtime"
 	"strconv"
 	"testing"
 
@@ -87,7 +88,7 @@ func TestFeatureCollection(t *testing.T) {
 
 			var featureCollection geojson.FeatureCollection
 			assert.NoError(t, featureCollection.UnmarshalJSON([]byte(tc.geoJSONStr)))
-			assert.Equal(t, tc.featureCollection, featureCollection)
+			assert.Equal(t, tc.featureCollection, featureCollection, assert.Exclude[runtime.Cleanup]())
 		})
 	}
 }

--- a/geom.go
+++ b/geom.go
@@ -16,13 +16,16 @@ type Geom struct {
 	context          *Context
 	cGeom            *C.struct_GEOSGeom_t
 	owner            *Geom
+	cleanup          runtime.Cleanup
 	typeID           TypeID
 	numGeometries    int
 	numInteriorRings int
 	numPoints        int
 }
 
-// NewCollection returns a new collection.
+// NewCollection returns a new collection which owns all the supplied
+// geometries; either directly if they were un-owned, or via clones if they
+// were owned already.
 func (c *Context) NewCollection(typeID TypeID, geoms []*Geom) *Geom {
 	if len(geoms) == 0 {
 		return c.NewEmptyCollection(typeID)
@@ -30,12 +33,20 @@ func (c *Context) NewCollection(typeID TypeID, geoms []*Geom) *Geom {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	cGeoms := make([]*C.GEOSGeometry, len(geoms))
-	for i, geom := range geoms {
-		cGeoms[i] = C.GEOSGeom_clone_r(c.cHandle, geom.cGeom)
+	for i, g := range geoms {
+		if g.owner == nil {
+			cGeoms[i] = g.cGeom
+		} else {
+			cGeoms[i] = C.GEOSGeom_clone_r(c.cHandle, g.cGeom)
+		}
 	}
 	geom := c.newNonNilGeom(C.GEOSGeom_createCollection_r(c.cHandle, C.int(typeID), &cGeoms[0], C.uint(len(geoms))), nil)
-	for _, childGeom := range geoms {
-		childGeom.owner = geom
+	for _, g := range geoms {
+		if g.owner == nil {
+			g.owner = geom
+			g.cleanup.Stop()
+			c.unref()
+		}
 	}
 	return geom
 }
@@ -212,8 +223,8 @@ func (g *Geom) ClipByBox2D(box2d *Box2D) *Geom {
 	return g.ClipByRect(box2d.MinX, box2d.MinY, box2d.MaxX, box2d.MaxY)
 }
 
-// CoordSeq returns g's coordinate sequence. The returned CoordSeq is owned by g
-// and is only valid for as long as g exists.
+// CoordSeq returns g's coordinate sequence. The returned CoordSeq is owned by
+// g and will keep it alive.
 func (g *Geom) CoordSeq() *CoordSeq {
 	g.context.mutex.Lock()
 	defer g.context.mutex.Unlock()
@@ -224,20 +235,19 @@ func (g *Geom) CoordSeq() *CoordSeq {
 	if coordSeq == nil {
 		return nil
 	}
-	coordSeq.owner = g
 	return coordSeq
 }
 
-// ExteriorRing returns the exterior ring. The returned geometry is owned by g
-// and is only valid for as long as g exists.
+// ExteriorRing returns the exterior ring. The returned geometry is a
+// sub-geometry of g and will keep it alive.
 func (g *Geom) ExteriorRing() *Geom {
 	g.context.mutex.Lock()
 	defer g.context.mutex.Unlock()
 	return g.context.newNonNilGeom(C.GEOSGetExteriorRing_r(g.context.cHandle, g.cGeom), g)
 }
 
-// Geometry returns the nth geometry of g. The returned geometry is owned by g
-// and is only valid for as long as g exists.
+// Geometry returns the nth geometry of g. The returned geometry is a
+// sub-geometry of g and will keep it alive.
 func (g *Geom) Geometry(n int) *Geom {
 	g.context.mutex.Lock()
 	defer g.context.mutex.Unlock()
@@ -247,8 +257,8 @@ func (g *Geom) Geometry(n int) *Geom {
 	return g.context.newNonNilGeom(C.GEOSGetGeometryN_r(g.context.cHandle, g.cGeom, C.int(n)), g)
 }
 
-// InteriorRing returns the nth interior ring. The returned geometry is owned by
-// g and is only valid for as long as g exists.
+// InteriorRing returns the nth interior ring. The returned geometry is a
+// sub-geometry of g and will keep it alive.
 func (g *Geom) InteriorRing(n int) *Geom {
 	g.context.mutex.Lock()
 	defer g.context.mutex.Unlock()
@@ -318,8 +328,7 @@ func (g *Geom) NumPoints() int {
 	return g.numPoints
 }
 
-// Point returns the g's nth point. The returned geometry is owned by g and is
-// only valid for as long as g exists.
+// Point returns the g's nth point.
 func (g *Geom) Point(n int) *Geom {
 	g.context.mutex.Lock()
 	defer g.context.mutex.Unlock()
@@ -466,7 +475,7 @@ func (c *Context) newGeom(cGeom *C.struct_GEOSGeom_t, owner *Geom) *Geom {
 	}
 	if owner == nil {
 		c.ref()
-		runtime.AddCleanup(geom, c.destroyGeom, cGeom)
+		geom.cleanup = runtime.AddCleanup(geom, c.destroyGeom, cGeom)
 	}
 	return geom
 }

--- a/geom_test.go
+++ b/geom_test.go
@@ -143,16 +143,16 @@ func TestGeometryMethods(t *testing.T) {
 			assert.Equal(t, 4326, g.SRID())
 			assert.Equal(t, tc.expectedArea, g.Area())
 			assert.Equal(t, tc.expectedLength, g.Length())
-			assert.Equal(t, v, g.MakeValidWithParams(geos.MakeValidLinework, geos.MakeValidDiscardCollapsed))
-			assert.Equal(t, v, g.MakeValidWithParams(geos.MakeValidStructure, geos.MakeValidDiscardCollapsed))
-			assert.Equal(t, v, g.MakeValidWithParams(geos.MakeValidLinework, geos.MakeValidKeepCollapsed))
+			assert.Equal(t, v, g.MakeValidWithParams(geos.MakeValidLinework, geos.MakeValidDiscardCollapsed), assert.Exclude[runtime.Cleanup]())
+			assert.Equal(t, v, g.MakeValidWithParams(geos.MakeValidStructure, geos.MakeValidDiscardCollapsed), assert.Exclude[runtime.Cleanup]())
+			assert.Equal(t, v, g.MakeValidWithParams(geos.MakeValidLinework, geos.MakeValidKeepCollapsed), assert.Exclude[runtime.Cleanup]())
 			var expectedValidStructureKeepCollapsed *geos.Geom
 			if tc.expectedValidWKTStructureKeepCollapsed != "" {
 				expectedValidStructureKeepCollapsed = mustNewGeomFromWKT(t, c, tc.expectedValidWKTStructureKeepCollapsed)
 			} else {
 				expectedValidStructureKeepCollapsed = v
 			}
-			assert.Equal(t, expectedValidStructureKeepCollapsed, g.MakeValidWithParams(geos.MakeValidStructure, geos.MakeValidKeepCollapsed))
+			assert.Equal(t, expectedValidStructureKeepCollapsed, g.MakeValidWithParams(geos.MakeValidStructure, geos.MakeValidKeepCollapsed), assert.Exclude[runtime.Cleanup]())
 		})
 	}
 }
@@ -452,10 +452,10 @@ func TestGeomPolygonizeFull(t *testing.T) {
 			c := geos.NewContext()
 			g := mustNewGeomFromWKT(t, c, tc.wkt)
 			actual, cuts, dangles, invalidRings := g.PolygonizeFull()
-			assert.Equal(t, mustNewGeomFromWKT(t, c, tc.expectedWKT), actual)
-			assert.Equal(t, mustNewGeomFromWKT(t, c, tc.expectedCutsWKT), cuts)
-			assert.Equal(t, mustNewGeomFromWKT(t, c, tc.expectedDanglesWKT), dangles)
-			assert.Equal(t, mustNewGeomFromWKT(t, c, tc.expectedInvalidRingsWKT), invalidRings)
+			assert.Equal(t, mustNewGeomFromWKT(t, c, tc.expectedWKT), actual, assert.Exclude[runtime.Cleanup]())
+			assert.Equal(t, mustNewGeomFromWKT(t, c, tc.expectedCutsWKT), cuts, assert.Exclude[runtime.Cleanup]())
+			assert.Equal(t, mustNewGeomFromWKT(t, c, tc.expectedDanglesWKT), dangles, assert.Exclude[runtime.Cleanup]())
+			assert.Equal(t, mustNewGeomFromWKT(t, c, tc.expectedInvalidRingsWKT), invalidRings, assert.Exclude[runtime.Cleanup]())
 		})
 	}
 }
@@ -503,13 +503,13 @@ func TestGeomToJSON(t *testing.T) {
 	assert.Equal(t, `{"type":"Point","coordinates":[1.0,2.0]}`, geom.ToGeoJSON(-1))
 }
 
-func TestWKBError(t *testing.T) {
+func TestWKTError(t *testing.T) {
 	_, err := geos.NewContext().NewGeomFromWKT("POINT (0 0")
 	assert.Error(t, err)
 	assert.Equal(t, err.Error(), "ParseException: Expected word but encountered end of stream")
 }
 
-func TestWKTError(t *testing.T) {
+func TestWKBError(t *testing.T) {
 	_, err := geos.NewContext().NewGeomFromWKB(nil)
 	assert.Error(t, err)
 	assert.Equal(t, err.Error(), "ParseException: Unexpected EOF parsing WKB")
@@ -625,10 +625,10 @@ func TestMakeValid(t *testing.T) {
 			v2 := mustNewGeomFromWKT(t, c, tc.expectedWktStructureDiscard)
 			v3 := mustNewGeomFromWKT(t, c, tc.expectedWktLineworkKeep)
 			v4 := mustNewGeomFromWKT(t, c, tc.expectedWktStructureKeep)
-			assert.Equal(t, v1, g.MakeValidWithParams(geos.MakeValidLinework, geos.MakeValidDiscardCollapsed))
-			assert.Equal(t, v2, g.MakeValidWithParams(geos.MakeValidStructure, geos.MakeValidDiscardCollapsed))
-			assert.Equal(t, v3, g.MakeValidWithParams(geos.MakeValidLinework, geos.MakeValidKeepCollapsed))
-			assert.Equal(t, v4, g.MakeValidWithParams(geos.MakeValidStructure, geos.MakeValidKeepCollapsed))
+			assert.Equal(t, v1, g.MakeValidWithParams(geos.MakeValidLinework, geos.MakeValidDiscardCollapsed), assert.Exclude[runtime.Cleanup]())
+			assert.Equal(t, v2, g.MakeValidWithParams(geos.MakeValidStructure, geos.MakeValidDiscardCollapsed), assert.Exclude[runtime.Cleanup]())
+			assert.Equal(t, v3, g.MakeValidWithParams(geos.MakeValidLinework, geos.MakeValidKeepCollapsed), assert.Exclude[runtime.Cleanup]())
+			assert.Equal(t, v4, g.MakeValidWithParams(geos.MakeValidStructure, geos.MakeValidKeepCollapsed), assert.Exclude[runtime.Cleanup]())
 		})
 	}
 }

--- a/geometry/geometry_test.go
+++ b/geometry/geometry_test.go
@@ -194,17 +194,17 @@ func TestNewGeometry(t *testing.T) {
 
 	actual, err := geometry.NewGeometryFromGeoJSON([]byte(`{"type":"Point","coordinates":[1,2]}`))
 	assert.NoError(t, err)
-	assert.Equal(t, expected, actual, assert.Exclude[*geos.Context]())
+	assert.Equal(t, expected, actual, assert.Exclude[*geos.Context](), assert.Exclude[runtime.Cleanup]())
 
 	wkb, err := hex.DecodeString("0101000000000000000000f03f0000000000000040")
 	assert.NoError(t, err)
 	actual, err = geometry.NewGeometryFromWKB(wkb)
 	assert.NoError(t, err)
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, expected, actual, assert.Exclude[runtime.Cleanup]())
 
 	actual, err = geometry.NewGeometryFromWKT("POINT (1 2)")
 	assert.NoError(t, err)
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, expected, actual, assert.Exclude[runtime.Cleanup]())
 }
 
 func TestIssue200(t *testing.T) {

--- a/wkbreader.go
+++ b/wkbreader.go
@@ -32,10 +32,12 @@ func (c *Context) NewWKBReader() *WKBReader {
 func (r *WKBReader) Read(wkb []byte) (*Geom, error) {
 	r.context.mutex.Lock()
 	defer r.context.mutex.Unlock()
-	wkbCBuf := C.CBytes(wkb)
-	defer C.free(wkbCBuf)
+	var pWkb *byte
+	if len(wkb) > 0 {
+		pWkb = &wkb[0]
+	}
 	r.context.err = nil
-	return r.context.newGeom(C.GEOSWKBReader_read_r(r.context.cHandle, r.cWKBReader, (*C.uchar)(wkbCBuf), C.size_t(len(wkb))), nil), r.context.err
+	return r.context.newGeom(C.GEOSWKBReader_read_r(r.context.cHandle, r.cWKBReader, (*C.uchar)(pWkb), C.size_t(len(wkb))), nil), r.context.err
 }
 
 func (c *Context) destroyWKBReader(cWKBReader *C.struct_GEOSWKBReader_t) {


### PR DESCRIPTION
For my particular workload, many UnaryUnions of many WKBs of various sizes, this change reduces the memory requirement from 3.4 GiB to 1 GiB.